### PR TITLE
Create mdbook.yml

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,0 +1,80 @@
+name: mdBook build
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'docs_src/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  MDBOOK_VERSION: ^0.4.13
+  MDBOOK_SRC: docs_src
+  MDBOOK_OUTPUT: docs
+  CARGO_TERM_COLOR: always
+  GIT_COMMITTER_NAME: "github-actions[bot]"
+  GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          toolchain: stable
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-rustc_${{ steps.toolchain.outputs.rustc_hash }}-mdbook-${{ hashFiles('book.toml', format('{0}{1}', env.MDBOOK_SRC, '/**')) }}
+          restore-keys: |
+            ${{ runner.os }}-rustc_${{ steps.toolchain.outputs.rustc_hash }}-mdbook-
+            ${{ runner.os }}-rustc_${{ steps.toolchain.outputs.rustc_hash }}
+
+      - name: Install mdBook
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: mdbook --vers "${{ env.MDBOOK_VERSION }}"
+
+      - name: Build mdBook
+        run: |
+          mdbook build
+
+      - name: Commit files
+        id: commit
+        run: |
+          git config --local user.email ${{ env.GIT_COMMITTER_EMAIL }}
+          git config --local user.name ${{ env.GIT_COMMITTER_NAME }}
+          git add -A ${{ env.MDBOOK_OUTPUT }}
+          git commit -m "Rebuild mdBook"
+
+      - name: Create a PR
+        id: pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GH_WORKFLOW_PUBLIC_REPO_PAC }}
+          committer: ${{ format( '{0} <{1}>', env.GIT_COMMITTER_NAME, env.GIT_COMMITTER_EMAIL) }}
+          branch: bot/mdbook
+          delete-branch: true
+          signoff: false
+          title: "[Bot] Rebuild mdBook"
+          body: |
+            **Update**:
+              - mdBook documentation
+          labels: |
+            documentation
+            automation


### PR DESCRIPTION
Automatically build mdBook on changes to `docs_src/**` (configurable).

NOTE: requires setting up a GH_WORKFLOW_PUBLIC_REPO_PAC repository secret
containing a personal access token with `public_repo` scope.
See: https://github.com/peter-evans/create-pull-request/issues/871